### PR TITLE
Do not offer create and delete widgets to teachers if they do not have the rights to use them, resolves #14 and #15

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -55,38 +55,47 @@ $PAGE->set_pagelayout('incourse');
 
 $html = '';
 
-// Get job create form for this activity.
-$driver = \local_archiving\driver\factory::activity_archiving_driver($cm->modname, $ctx);
-$form = $driver->get_job_create_form($cm->modname, $cm);
+// Check capabilities.
+$cancreate = has_capability('local/archiving:create', $ctx);
 
-// Handle form submission.
-if ($form->is_cancelled()) {
-    redirect(new \moodle_url('/local/archiving/index.php', ['courseid' => $courseid]));
-}
+// Only build and process the job create form if the user is allowed to create archives.
+$jobcreateformhtml = '';
+if ($cancreate) {
+    // Get job create form for this activity.
+    $driver = \local_archiving\driver\factory::activity_archiving_driver($cm->modname, $ctx);
+    $form = $driver->get_job_create_form($cm->modname, $cm);
 
-if ($form->is_submitted() && $form->is_validated()) {
-    require_capability('local/archiving:create', $ctx);
-
-    // Ensure that manual archive job creation is enabled.
-    if (!\local_archiving\driver\factory::archiving_trigger('manual')->is_enabled()) {
-        // We should never get here if nobody messes with the form. But who knows how creative people might get ;) ...
-        throw new \moodle_exception('manual_job_creation_disabled', 'local_archiving');
+    // Handle form submission.
+    if ($form->is_cancelled()) {
+        redirect(new \moodle_url('/local/archiving/index.php', ['courseid' => $courseid]));
     }
 
-    $jobsettings = $form->get_data();
-    if (!$jobsettings) {
-        throw new \moodle_exception('job_create_form_data_empty', 'local_archiving');
-    }
-    $job = \local_archiving\archive_job::create($ctx, $USER->id, 'manual', $jobsettings);
-    $job->enqueue();
+    if ($form->is_submitted() && $form->is_validated()) {
+        require_capability('local/archiving:create', $ctx);
 
-    $html .= $OUTPUT->notification(
-        get_string('archive_job_created_details', 'local_archiving', [
-            'jobid' => $job->get_id(),
-            'cmname' => $cm->name,
-        ]),
-        'success'
-    );
+        // Ensure that manual archive job creation is enabled.
+        if (!\local_archiving\driver\factory::archiving_trigger('manual')->is_enabled()) {
+            // We should never get here if nobody messes with the form. But who knows how creative people might get ;) ...
+            throw new \moodle_exception('manual_job_creation_disabled', 'local_archiving');
+        }
+
+        $jobsettings = $form->get_data();
+        if (!$jobsettings) {
+            throw new \moodle_exception('job_create_form_data_empty', 'local_archiving');
+        }
+        $job = \local_archiving\archive_job::create($ctx, $USER->id, 'manual', $jobsettings);
+        $job->enqueue();
+
+        $html .= $OUTPUT->notification(
+            get_string('archive_job_created_details', 'local_archiving', [
+                'jobid' => $job->get_id(),
+                'cmname' => $cm->name,
+            ]),
+            'success'
+        );
+    }
+
+    $jobcreateformhtml = $form->render();
 }
 
 // Prepare template context for page.
@@ -98,7 +107,7 @@ $jobtablehtml = ob_get_contents();
 ob_end_clean();
 
 $tplctx = [
-    'jobcreateformhtml' => $form->render(),
+    'jobcreateformhtml' => $jobcreateformhtml,
     'jobtablehtml' => $jobtablehtml,
     'modfullname' => $cm->modfullname,
     'urls' => [

--- a/classes/output/job_overview_table.php
+++ b/classes/output/job_overview_table.php
@@ -209,14 +209,17 @@ class job_overview_table extends \table_sql {
         $html .= '<a href="'.$logurl.'" class="btn btn-info mx-1" role="button" data-toggle="tooltip" data-placement="top" title="'.get_string('logs').'" alt="'.get_string('logs').'"><i class="fa fa-file-waveform"></i></a>';
 
         // Action: Delete.
-        $deleteurl = new \moodle_url('/local/archiving/manage.php', [
-            'action' => 'jobdelete',
-            'contextid' => $values->contextid,
-            'jobid' => $values->id,
-            'wantsurl' => $PAGE->url->out(true),
-        ]);
-        // phpcs:ignore
-        $html .= '<a href="'.$deleteurl.'" class="btn btn-danger mx-1" role="button" data-toggle="tooltip" data-placement="top" title="'.get_string('delete').'" alt="'.get_string('delete').'"><i class="fa fa-trash"></i></a>';
+        // Only shown to users that are allowed to delete archives in the job's context.
+        if (has_capability('local/archiving:delete', \context::instance_by_id($values->contextid))) {
+            $deleteurl = new \moodle_url('/local/archiving/manage.php', [
+                'action' => 'jobdelete',
+                'contextid' => $values->contextid,
+                'jobid' => $values->id,
+                'wantsurl' => $PAGE->url->out(true),
+            ]);
+            // phpcs:ignore
+            $html .= '<a href="'.$deleteurl.'" class="btn btn-danger mx-1" role="button" data-toggle="tooltip" data-placement="top" title="'.get_string('delete').'" alt="'.get_string('delete').'"><i class="fa fa-trash"></i></a>';
+        }
 
         return $html;
     }

--- a/index.php
+++ b/index.php
@@ -49,6 +49,7 @@ $PAGE->set_url(new \moodle_url(
 $PAGE->set_pagelayout('incourse');
 
 // Build context for page template.
+$cancreate = has_capability('local/archiving:create', $ctx);
 $archivingenabled = course_util::archiving_enabled_for_course($courseid);
 $archivingenableforced = false;
 if (!$archivingenabled && has_capability('local/archiving:bypasscourserestrictions', $ctx)) {
@@ -58,6 +59,7 @@ if (!$archivingenabled && has_capability('local/archiving:bypasscourserestrictio
 }
 
 $tplctx = [
+    'cancreate' => $cancreate,
     'archivingenabled' => $archivingenabled,
     'archivingenableforced' => $archivingenableforced,
     'hidedisabledcms' => $excludedisabledcms,
@@ -67,7 +69,7 @@ $tplctx = [
     ]),
 ];
 
-if ($archivingenabled) {
+if ($archivingenabled && $cancreate) {
     foreach (mod_util::get_cms_with_metadata($courseid, $excludedisabledcms) as $obj) {
         $tplctx['cms'][] = [
             'id' => $obj->cm->id,

--- a/lang/en/local_archiving.php
+++ b/lang/en/local_archiving.php
@@ -80,7 +80,8 @@ $string['archiving:bypasscourserestrictions'] = 'Bypass course category restrict
 // Archiving overview.
 $string['activity_archiving_list_desc'] = 'Below you can find a list of all activities in this course. Supported activities can be archived by clicking the respective entry in the list. If an activity is not supported, it will be disabled.';
 $string['archive_jobs_course_table_desc'] = 'This table lists all archive jobs that have been created for any of the activities in this course.';
-$string['archiving_course_overview_desc'] = 'This page is allows to create and access archives for all supported activities in this course.';
+$string['archiving_course_overview_desc'] = 'This page allows to create and access archives for all supported activities in this course.';
+$string['archiving_course_overview_readonly_desc'] = 'This page allows to access archives for all supported activities in this course.';
 $string['badge_archived_help'] = 'This activity was successfully archived at the given time.';
 $string['badge_cannot_be_archived_help'] = 'This activity can currently not be archived due to an unknown reason.';
 $string['badge_disabled_help'] = 'Archiving this activity type is currently disabled by the system administrator.';

--- a/manage.php
+++ b/manage.php
@@ -57,6 +57,9 @@ $PAGE->set_heading($course->fullname);
 // Handle POSTed data.
 $outhtml = '';
 if ($action === 'jobdelete') {
+    // Deleting archives requires the delete capability, even for displaying the confirmation form.
+    require_capability('local/archiving:delete', $ctx);
+
     $jobid = required_param('jobid', PARAM_INT);
     $PAGE->set_url(new moodle_url(
         '/local/archiving/manage.php',
@@ -73,8 +76,6 @@ if ($action === 'jobdelete') {
     if ($form->is_cancelled()) {
         redirect($wantsurl);
     } else if ($form->is_submitted() && $form->is_validated()) {
-        require_capability('local/archiving:delete', $ctx);
-
         // Perform deletion.
         $job = archive_job::get_by_id($jobid);
         $job->delete();
@@ -84,6 +85,9 @@ if ($action === 'jobdelete') {
         $outhtml .= $form->render();
     }
 } else if ($action === 'filedelete') {
+    // Deleting archive files requires the delete capability, even for displaying the confirmation form.
+    require_capability('local/archiving:delete', $ctx);
+
     $filehandleid = required_param('filehandleid', PARAM_INT);
     $PAGE->set_url(new moodle_url(
         '/local/archiving/manage.php',
@@ -100,8 +104,6 @@ if ($action === 'jobdelete') {
     if ($form->is_cancelled()) {
         redirect($wantsurl);
     } else if ($form->is_submitted() && $form->is_validated()) {
-        require_capability('local/archiving:delete', $ctx);
-
         // Perform deletion.
         $filehandle = file_handle::get_by_id($filehandleid);
         $filehandle->archivingstore()->delete($filehandle);

--- a/templates/archive.mustache
+++ b/templates/archive.mustache
@@ -32,11 +32,13 @@
 
 
 <div class="container">
+    {{#jobcreateformhtml}}
     <div class="row">
         <div class="col-12">
             {{{jobcreateformhtml}}}
         </div>
     </div>
+    {{/jobcreateformhtml}}
 
     <div class="row">
         <div class="col-12">

--- a/templates/download_job_artifacts.mustache
+++ b/templates/download_job_artifacts.mustache
@@ -191,13 +191,10 @@
                             </a>
                             {{#deleteurl}}
                                 <a href="{{{deleteurl}}}" class="btn btn-danger mx-1" role="button">
+                                    <i class="fa fa-trash"></i>&nbsp;
+                                    {{#str}} delete {{/str}}
+                                </a>
                             {{/deleteurl}}
-                            {{^deleteurl}}
-                                <a href="#" class="btn btn-outline-danger mx-1 disabled" role="button" aria-disabled="true">
-                            {{/deleteurl}}
-                                <i class="fa fa-trash"></i>&nbsp;
-                                {{#str}} delete {{/str}}
-                            </a>
                         {{/deleted}}
                         {{#deleted}}
                             <span class="text-muted">

--- a/templates/overview_course.mustache
+++ b/templates/overview_course.mustache
@@ -21,6 +21,7 @@
 
     Example context (json):
     {
+        "cancreate": true,
         "archivingenabled": true,
         "archivingenableforced": false,
         "cms": [
@@ -47,10 +48,16 @@
         <div class="col-12">
             <h1>{{#str}} archiving, local_archiving {{/str}}</h1>
             <p>
-                {{#str}} archiving_course_overview_desc, local_archiving {{/str}}
+                {{#cancreate}}
+                    {{#str}} archiving_course_overview_desc, local_archiving {{/str}}
+                {{/cancreate}}
+                {{^cancreate}}
+                    {{#str}} archiving_course_overview_readonly_desc, local_archiving {{/str}}
+                {{/cancreate}}
             </p>
         </div>
     </div>
+    {{#cancreate}}
     {{#archivingenabled}}
         <div class="row mt-2">
             <div class="col-12">
@@ -209,6 +216,7 @@
             </div>
         </div>
     {{/archivingenabled}}
+    {{/cancreate}}
     <div class="row mt-3">
         <div class="col-12">
             <h3>{{#str}} archive_jobs, local_archiving {{/str}}</h3>


### PR DESCRIPTION
This PR fixes the raised issues and was manually tested.

Please note that there aren't any automated tests for these fixes included as they are not straightforward to be tested with PHPUnit (which exist already in the plugin) and as there isn't a Behat test baseline yet (which I could have extended to cover these cases)